### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,8 @@ jobs:
   test:
     name: Run on Ubuntu
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Clone the code
         uses: actions/checkout@v5


### PR DESCRIPTION
Potential fix for [https://github.com/nusnewob/kube-changejob/security/code-scanning/4](https://github.com/nusnewob/kube-changejob/security/code-scanning/4)

In general, the fix is to explicitly define a `permissions:` block so that the `GITHUB_TOKEN` used in this workflow is limited to the minimal required scopes. For a test-only job that simply checks out code, sets up Go, and runs tests locally, `contents: read` is sufficient, since no action writes back to the repository or interacts with issues, PRs, or other resources.

The best fix here, without changing existing functionality, is to add a `permissions:` section to the `test` job. This keeps the change tightly scoped and avoids affecting other workflows or jobs. Specifically, in `.github/workflows/test.yml`, under `jobs:`, inside the `test:` job and aligned with `runs-on:`, add:
```yaml
    permissions:
      contents: read
```
No new imports or methods are needed, as this is just a YAML configuration change in the workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
