### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -1,5 +1,8 @@
 name: E2E Tests
 
+permissions:
+  contents: read
+
 on:
   push:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/nusnewob/kube-changejob/security/code-scanning/3](https://github.com/nusnewob/kube-changejob/security/code-scanning/3)

To fix this, explicitly define minimal `GITHUB_TOKEN` permissions in the workflow. Since this job only checks out the repository and runs tests, it only needs read access to repository contents. The safest and simplest fix that preserves existing behavior is to add a `permissions` block at the workflow (root) level, directly under `name: E2E Tests`. This applies to all jobs in the workflow (currently only `test-e2e`) and sets `contents: read`, which is the recommended minimal baseline for typical CI jobs that only read code.

Concretely, in `.github/workflows/test-e2e.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `name: E2E Tests` line and the `on:` block. No additional imports or methods are required, and no other parts of the workflow need to change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
