### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-chart.yml
+++ b/.github/workflows/test-chart.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test-e2e:
     name: Run on Ubuntu


### PR DESCRIPTION
Potential fix for [https://github.com/nusnewob/kube-changejob/security/code-scanning/2](https://github.com/nusnewob/kube-changejob/security/code-scanning/2)

In general, the fix is to add an explicit `permissions` block to the workflow or to the specific job so that the `GITHUB_TOKEN` is limited to the minimum required scopes. For this particular workflow, the job only needs to read repository contents (for `actions/checkout`) and does not need to write to the repo or interact with issues/PRs, so `contents: read` is sufficient.

The best minimal fix without changing existing functionality is to add a `permissions` block at the workflow root, right after the `on:` triggers and before `jobs:`. This will apply to all jobs in this workflow (currently just `test-e2e`). Concretely, in `.github/workflows/test-chart.yml`, after the `pull_request:` trigger block and the blank line that follows it, insert:

```yaml
permissions:
  contents: read
```

No additional imports or methods are required, since this is a YAML configuration change within the workflow file only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
