### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   lint:
     name: Run on Ubuntu
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Clone the code


### PR DESCRIPTION
Potential fix for [https://github.com/nusnewob/kube-changejob/security/code-scanning/1](https://github.com/nusnewob/kube-changejob/security/code-scanning/1)

To fix this, explicitly define a restrictive `permissions` block so that the `GITHUB_TOKEN` has only the access needed for linting. Since all the steps do is check out the repository and run tooling, they only need read access to repository contents. The minimal, least‑privilege fix is to add `permissions: contents: read` either at the workflow root (affecting all jobs) or inside the `lint` job. Following the CodeQL suggestion and keeping the scope narrow, we will add a `permissions` block to the `lint` job.

Concretely, in `.github/workflows/lint.yml`, under `jobs: lint:`, insert:

```yaml
    permissions:
      contents: read
```

between the `name: Run on Ubuntu` and `runs-on: ubuntu-latest` lines. No imports or additional methods are needed because this is purely a YAML configuration change within the GitHub Actions workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
